### PR TITLE
Allow templating serviceaccount annotations

### DIFF
--- a/charts/external-dns/templates/serviceaccount.yaml
+++ b/charts/external-dns/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}


### PR DESCRIPTION
This is specially useful when you want to use WorkloadIdentity or IRSA to grant external-dns ksa access to GCP Cloud DNS or AWS Route53

<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
Adds the ability to template annotations as dynamic values. In our use case we have many clusters living in different clouds/accounts. Instead of hardcoding in values cloud environment metadata, we inject these configs dynamically. So this way we can do things like:

```
serviceAccount:
   annotations:
       iam.gke.io/gcp-service-account=external-dns@{{ .Values.mygcpProject }}.iam.gserviceaccount.com
```
Similar for AWS IRSA.

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
